### PR TITLE
Add an issue template chooser and pre-fill template titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,3 +7,6 @@ contact_links:
 - name: Security Policy
   url: https://pypi.org/security/
   about: Please learn how to report security vulnerabilities here.
+- name: PyPA Code of Conduct
+  url: https://www.pypa.io/en/latest/code-of-conduct/
+  about: ❤ Be nice to other members of the community. ☮ Behave.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true  # default
+contact_links:
+- name: Feature Request, UX issue or bug?
+  url: https://github.com/pypa/warehouse/issues/new/choose
+  about: Please open these under `pypa/warehouse`.
+- name: Security Policy
+  url: https://pypi.org/security/
+  about: Please learn how to report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,10 +3,10 @@ blank_issues_enabled: true  # default
 contact_links:
 - name: Feature Request, UX issue or bug?
   url: https://github.com/pypa/warehouse/issues/new/choose
-  about: Please open these under `pypa/warehouse`.
+  about: Please open these under `pypa/warehouse`
 - name: Security Policy
   url: https://pypi.org/security/
-  about: Please learn how to report security vulnerabilities here.
+  about: Please learn how to report security vulnerabilities here
 - name: PyPA Code of Conduct
   url: https://www.pypa.io/en/latest/code-of-conduct/
   about: ❤ Be nice to other members of the community. ☮ Behave.

--- a/.github/ISSUE_TEMPLATE/limit-request.md
+++ b/.github/ISSUE_TEMPLATE/limit-request.md
@@ -3,6 +3,7 @@ name: "Limit Request: PROJECT_NAME - 60MB"
 title: "Limit Request: PROJECT_NAME - 60MB"
 about: You want to request a file size limit increase
 labels: limit request
+assignees: di
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/limit-request.md
+++ b/.github/ISSUE_TEMPLATE/limit-request.md
@@ -1,7 +1,8 @@
 ---
 name: "Limit Request: PROJECT_NAME - 60MB"
+title: "Limit Request: PROJECT_NAME - 60MB"
 about: You want to request a file size limit increase
-labels: "limit request"
+labels: limit request
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/limit-request.md
+++ b/.github/ISSUE_TEMPLATE/limit-request.md
@@ -3,7 +3,6 @@ name: "Limit Request: PROJECT_NAME - 60MB"
 title: "Limit Request: PROJECT_NAME - 60MB"
 about: You want to request a file size limit increase
 labels: limit request
-assignees: di
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/new-trove-classifier.md
+++ b/.github/ISSUE_TEMPLATE/new-trove-classifier.md
@@ -1,7 +1,9 @@
 ---
 name: Trove Classifier Request
+title: Trove Classifier Request
 about: Request a new trove classifier
-labels: "classifier request"
+labels: classifier request
+
 ---
 
 Request to add a new Trove classifier.

--- a/.github/ISSUE_TEMPLATE/pep541-request.md
+++ b/.github/ISSUE_TEMPLATE/pep541-request.md
@@ -3,6 +3,7 @@ name: "PEP 541 Request: PROJECT_NAME"
 title: "PEP 541 Request: PROJECT_NAME"
 about: You want to claim or flag a project in accordance to PEP 541
 labels: PEP 541
+assignees: yeraydiazdiaz
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/pep541-request.md
+++ b/.github/ISSUE_TEMPLATE/pep541-request.md
@@ -1,5 +1,6 @@
 ---
 name: "PEP 541 Request: PROJECT_NAME"
+title: "PEP 541 Request: PROJECT_NAME"
 about: You want to claim or flag a project in accordance to PEP 541
 labels: PEP 541
 

--- a/.github/ISSUE_TEMPLATE/pep541-request.md
+++ b/.github/ISSUE_TEMPLATE/pep541-request.md
@@ -3,7 +3,6 @@ name: "PEP 541 Request: PROJECT_NAME"
 title: "PEP 541 Request: PROJECT_NAME"
 about: You want to claim or flag a project in accordance to PEP 541
 labels: PEP 541
-assignees: yeraydiazdiaz
 
 ---
 


### PR DESCRIPTION
Added:

* titles
* assignees
* template chooser config

(similar PR for Pip: https://github.com/pypa/pip/pull/7630/files; examples of how this looks: https://github.com/ansible/ansible/issues/new/choose, https://github.com/ansible/pylibssh/issues/new/choose, https://github.com/cherrypy/cheroot/issues/new/choose, https://github.com/sphinx-doc/sphinx/issues/new/choose)