### PR TITLE
The PyPA has adopted the PSF code of conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,6 +7,6 @@ contact_links:
 - name: Security Policy
   url: https://pypi.org/security/
   about: Please learn how to report security vulnerabilities here
-- name: PyPA Code of Conduct
-  url: https://www.pypa.io/en/latest/code-of-conduct/
+- name: PSF Code of Conduct
+  url: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
   about: ❤ Be nice to other members of the community. ☮ Behave.

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ To read the most up to date version of our security policy, including directions
 Please [create a new issue here](https://github.com/pypa/pypi-support/issues/new/choose) and it will be transferred as necessary.
 
 ## Code of Conduct
-Everyone interacting in the PyPI Support project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).
+Everyone interacting in the PyPI's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ To read the most up to date version of our security policy, including directions
 Please [create a new issue here](https://github.com/pypa/pypi-support/issues/new/choose) and it will be transferred as necessary.
 
 ## Code of Conduct
-Everyone interacting in the Warehouse project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [PyPA Code of Conduct](https://www.pypa.io/en/latest/code-of-conduct/).
+Everyone interacting in the PyPI Support project's codebases, issue trackers, chat rooms, and mailing lists is expected to follow the [PSF Code of Conduct](https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
For details, see:

* https://discuss.python.org/t/implementing-pep-609-pypa-governance/4745