### PR TITLE
Update the subtext for the Code of Conduct link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,4 +9,4 @@ contact_links:
   about: Please learn how to report security vulnerabilities here
 - name: PSF Code of Conduct
   url: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
-  about: For all Code of Conduct related latters, please refer to this document. Take care ❤️.
+  about: For all Code of Conduct related matters, please refer to this document.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,4 +9,4 @@ contact_links:
   about: Please learn how to report security vulnerabilities here
 - name: PSF Code of Conduct
   url: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
-  about: ❤ Be nice to other members of the community. ☮ Behave.
+  about: For all Code of Conduct related latters, please refer to this document. Take care ❤️.


### PR DESCRIPTION
If someone clicks on "New issue" looking for CoC-related help, they're most likely in need of help, not in need of people telling them to be nice & behave.

I've tried to keep a bit of the ❤️ caring tone of the original message, while removing injunctions (well technically take care is an injunction...)

Cc Code of conduct team: @di @gaborbernat @dstufft 