### PR TITLE
Make "Yes" a string in `limit-request.yml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/limit-request.yml
+++ b/.github/ISSUE_TEMPLATE/limit-request.yml
@@ -40,7 +40,7 @@ body:
       You can create an empty 0.0.0 release and delete it immediately if
       it doesn't already exist.
     options:
-    - label: Yes
+    - label: "Yes"  # should be a str but YAML parses unwrapped yes/no as bool
       required: true
 
 - type: input


### PR DESCRIPTION
@di GitHub's schema validator expects checkbox labels to be strings but YAML parser turns things like "yes"/"no" into bool implicitly. So I doublequoted one such violation.

It's a follow-up for #927 and #926. I hope it's the last one.