### PR TITLE
Make index selection required in limit-request.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/limit-request.yml
+++ b/.github/ISSUE_TEMPLATE/limit-request.yml
@@ -67,6 +67,8 @@ body:
     options:
     - PyPI
     - TestPyPI
+  validations:
+    required: true
 
 - type: input
   attributes:


### PR DESCRIPTION
This makes sure that the submitters select at least one package index.