### PR TITLE
Drop a deprecated settings from the issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/access-issues.yml
+++ b/.github/ISSUE_TEMPLATE/access-issues.yml
@@ -2,7 +2,6 @@
 name: Network Access Issues
 description: Let us know if you're having trouble reaching PyPI
 labels: network
-title: ''
 issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
 
 body:

--- a/.github/ISSUE_TEMPLATE/access-issues.yml
+++ b/.github/ISSUE_TEMPLATE/access-issues.yml
@@ -2,7 +2,6 @@
 name: Network Access Issues
 description: Let us know if you're having trouble reaching PyPI
 labels: network
-issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
 
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/account-recovery.yml
+++ b/.github/ISSUE_TEMPLATE/account-recovery.yml
@@ -3,7 +3,6 @@ name: Account Recovery
 description: Initiate an account recovery due to lost 2FA or inability to access email address
 title: Account recovery request
 labels: account-recovery 
-issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
 
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/limit-request.yml
+++ b/.github/ISSUE_TEMPLATE/limit-request.yml
@@ -7,7 +7,6 @@ description: >-
   You want to request a file size limit or project total size
   limit increase
 labels: limit request
-issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
 
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/pep541-request.yml
+++ b/.github/ISSUE_TEMPLATE/pep541-request.yml
@@ -3,7 +3,6 @@ name: "PEP 541 Request: PROJECT_NAME"
 title: "PEP 541 Request: PROJECT_NAME"
 description: You want to claim or flag a project in accordance to PEP 541
 labels: PEP 541
-issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
 
 body:
 - type: markdown


### PR DESCRIPTION
The empty title in `access-issues.yml` makes it disappear from the list.

@di @ewdurbin could any of you merge this ASAP to fix that?