### PR TITLE
Add mass name squatting issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/mass-name-squatter.yml
+++ b/.github/ISSUE_TEMPLATE/mass-name-squatter.yml
@@ -1,0 +1,46 @@
+---
+name: "Mass name squat by user: USERNAME"
+title: "Mass name squat by user: USERNAME"
+description: You want to report mass project name squatting by a PyPI user
+labels: mass name squat
+
+body:
+- type: markdown
+  attributes:
+    value: |
+      A PyPI user has registered a large number of projects with what you
+      believe is an attempt to reserve their names or otherwise abuse the
+      service.
+      
+- type: input
+  attributes:
+    label: PyPI user performing the mass project name squatting
+    description: |
+      Please also **update the issue title** as well.
+    value: |
+      https://pypi.org/user/USERNAME
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Reasons for the request
+    description: |
+      Why do you think the user is engaging in mass project name squatting?
+
+      Please provide details about the number of projects, whether you consider
+      them invalid and why.
+  validations:
+    required: true
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [PSF Code of Conduct][CoC] first.
+
+      [CoC]: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
+    options:
+    - label: I agree to follow the PSF Code of Conduct
+      required: true
+...

--- a/.github/ISSUE_TEMPLATE/mass-name-squatter.yml
+++ b/.github/ISSUE_TEMPLATE/mass-name-squatter.yml
@@ -24,14 +24,12 @@ body:
 
 - type: textarea
   attributes:
-    label: Reasons for the request
+    label: Additional information
     description: |
-      Why do you think the user is engaging in mass project name squatting?
+      Any information you think might be useful for the moderators.
 
-      Please provide details about the number of projects, whether you consider
-      them invalid and why.
   validations:
-    required: true
+    required: false
 
 - type: checkboxes
   attributes:


### PR DESCRIPTION
There are already a few of these and users tend to tag them as PEP 541 which is correct to an extent but the resolution process is different.

I manually added the `mass name squat` label and applying them to existing issues.