### PR TITLE
Include default limits in issue form descriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/limit-request-file.yml
+++ b/.github/ISSUE_TEMPLATE/limit-request-file.yml
@@ -1,7 +1,7 @@
 ---
 name: Size Limit Request (per-file)
 title: "File Limit Request: PROJECT_NAME - 000 MB"
-description: Your release files are larger than the per-file limit.
+description: "Your release files are larger than the per-file limit. (default: 100 MB)"
 labels: limit request
 
 body:

--- a/.github/ISSUE_TEMPLATE/limit-request-project.yml
+++ b/.github/ISSUE_TEMPLATE/limit-request-project.yml
@@ -1,7 +1,7 @@
 ---
 name: Size Limit Request (project-wide)
 title: "Project Limit Request: PROJECT_NAME - 00 GB"
-description: Your project has hit the total project size limit.
+description: "Your project has hit the total project size limit. (default: 10 GB)"
 labels: limit request
 
 body:


### PR DESCRIPTION
These will make it more likely that users use the correct form for the
kind of limit they are hitting.